### PR TITLE
Dockerfile, workflow for download image with Docker in DockerHub

### DIFF
--- a/src/main/java/com/example/datageneratormicroservice/config/BeanConfig.java
+++ b/src/main/java/com/example/datageneratormicroservice/config/BeanConfig.java
@@ -13,7 +13,7 @@ public class BeanConfig {
     @Bean
     public XML producerXML() {
         return new XMLDocument(
-                getClass().getResourceAsStream("/kafka/consumer.xml").readAllBytes()
+                getClass().getResourceAsStream("/kafka/producer.xml").readAllBytes()
         );
     }
 


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the file path in `BeanConfig.java` to correctly read from `producer.xml` instead of `consumer.xml`.

### Detailed summary
- Updated file path to read from `producer.xml` instead of `consumer.xml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->